### PR TITLE
fix nhanesSearch() bug

### DIFF
--- a/R/nhanesDB.R
+++ b/R/nhanesDB.R
@@ -326,9 +326,8 @@
   if (!is.null(exclude_terms)) {
     exclude_terms <- paste(exclude_terms, collapse = "|")
     query <- dplyr::filter(query,
-                           str_detect(tolower(Description.x),
-                                      tolower(exclude_terms),
-                                      negate = TRUE))
+                           !str_detect(tolower(Description.x),
+                                       tolower(exclude_terms)))
   }
 
   # Apply data group filter


### PR DESCRIPTION
By placing ! before str_detect, you negate the logical result in R, which dplyr can then translate into the appropriate NOT operator in SQL.