### PR TITLE
Update URLs and minimum changes for browseNHANES()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: nhanesA
-Version: 1.2.0
+Version: 1.2.2
 Date: 2024-12-18
 Title: NHANES Data Retrieval
 Authors@R:

--- a/R/nhanes.R
+++ b/R/nhanes.R
@@ -397,7 +397,7 @@ browseNHANES <- function(year = NULL, data_group = NULL, nh_table = NULL,
   } else if(!is.null(year)) {
     if(!is.null(data_group)) {
       nh_year <- .get_nh_survey_years(year)
-      url <- paste0(nhanesSearchURL, 'Search/DataPage.aspx?Component=', 
+      url <- paste0(nhanesURL, 'Search/DataPage.aspx?Component=', 
                     nhanes_group[data_group],
                     '&CycleBeginYear=', unlist(str_split(nh_year, '-'))[[1]])
       handleURL(url)
@@ -405,7 +405,7 @@ browseNHANES <- function(year = NULL, data_group = NULL, nh_table = NULL,
       nh_year <- .get_nh_survey_years(year)
 #      nh_year <- str_c(str_sub(unlist(str_extract_all(nh_year,"[[:digit:]]{4}")),3,4),collapse='_')
       nh_year <- unlist(str_extract_all(nh_year, "[[:digit:]]{4}"))[1]
-      url <- paste0(nhanesSearchURL, 'continuousnhanes/default.aspx?BeginYear=', nh_year)
+      url <- paste0(nhanesURL, 'continuousnhanes/default.aspx?BeginYear=', nh_year)
       handleURL(url)
     }
   } else {

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -32,13 +32,13 @@ ladDataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx?Component=L
 dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"
 dxaTablesURL  <- "https://wwwn.cdc.gov/Nchs/Nhanes/Dxa/Dxa.aspx"
 
-demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Demographics"
-dietURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Dietary"
-examURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Examination"
-labURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Laboratory"
-qURL    <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Questionnaire"
-ladURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=LimitedAccess"
-varURLs <- c(demoURL, dietURL, examURL, labURL, qURL) 
+demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Demographics"
+dietURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Dietary"
+examURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Examination"
+labURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Laboratory"
+qURL    <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Questionnaire"
+ladURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=LimitedAccess"
+varURLs <- c(demoURL, dietURL, examURL, labURL, qURL) #, ladURL)
 
 
 # Create a list of nhanes groups

--- a/R/nhanes_constants.R
+++ b/R/nhanes_constants.R
@@ -26,20 +26,19 @@ ab_nhanesManifestPrefix <- function(x) {
 }
 
 
-nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/'
-nhanesSearchURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
+nhanesURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/'
 dataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx'
 ladDataURL <- 'https://wwwn.cdc.gov/Nchs/Nhanes/search/DataPage.aspx?Component=LimitedAccess'
 dxaURL  <- "https://wwwn.cdc.gov/nchs/data/nhanes/dxa/"
 dxaTablesURL  <- "https://wwwn.cdc.gov/Nchs/Nhanes/Dxa/Dxa.aspx"
 
-demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Demographics"
-dietURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Dietary"
-examURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Examination"
-labURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Laboratory"
-qURL    <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=Questionnaire"
-ladURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/variablelist.aspx?Component=LimitedAccess"
-varURLs <- c(demoURL, dietURL, examURL, labURL, qURL) #, ladURL)
+demoURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Demographics"
+dietURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Dietary"
+examURL <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Examination"
+labURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Laboratory"
+qURL    <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=Questionnaire"
+ladURL  <- "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx?Component=LimitedAccess"
+varURLs <- c(demoURL, dietURL, examURL, labURL, qURL) 
 
 
 # Create a list of nhanes groups


### PR DESCRIPTION
Replace the outdate URL with working ones.

Users reported something like:
```
> nhanesTables('EXAM', 2005)
URL https://wwwn.cdc.gov/Nchs/Data/Nhanes/Public/search/variablelist.aspx?Component=Examination&CycleBeginYear=2005 does not seem to exist
Error occurred during read. No tables returned
```
I fixed it by updating the URLs.